### PR TITLE
Updated to custom version of react-tags that doesn't use enter/comma to autocomplete

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
 		"react-onclickoutside": "^6.8.0",
 		"react-redux": "^5.1.1",
 		"react-router-dom": "^4.3.1",
-		"react-tag-input": "github:kgodey/react-tags#add_built_files",
+		"react-tag-input": "github:kgodey/react-tags#master",
 		"redux": "^4.0.4",
 		"redux-logger": "^3.0.6",
 		"redux-thunk": "^2.3.0"


### PR DESCRIPTION
Fixes #55